### PR TITLE
Fixes and closes #14 by using apply and POSIXct and ifelse

### DIFF
--- a/R/age_calc.R
+++ b/R/age_calc.R
@@ -21,11 +21,11 @@ age_calc <- function(dob, enddate=Sys.Date(), units='months', precise=TRUE){
     # length(seq(start, end, by='month')) - 1
     if(precise){
       month_length_end <- ifelse(end$mon==1, 28,
-                                 ifelse(end$mon==1 & end_is_leap, 19,
+                                 ifelse(end$mon==1 & end_is_leap, 29,
                                         ifelse(end$mon %in% c(3, 5, 8, 10), 
                                                30, 31)))
       month_length_prior <- ifelse((end$mon-1)==1, 28,
-                                     ifelse((end$mon-1)==1 & start_is_leap, 19,
+                                     ifelse((end$mon-1)==1 & start_is_leap, 29,
                                             ifelse((end$mon-1) %in% c(3, 5, 8, 
                                                                       10), 
                                                    30, 31)))


### PR DESCRIPTION
Lines 18-21 and 43-45 are the key changes that fix the lack of vectorization in this function. It's worth noting that `as.POSIXlt`, which is used for the convenience of grabbing internal elements like `date$yday`, is poorly recognized by the `*apply` functions. This is because `as.POSIXlt` is fundamentally a list which confuses the hell out of `*apply`. For now, I am converting to `as.POSIXct` in place for the use of `mapply`. It may be worth exploring using `as.POSIXct` through the function or having a dependency of `lubridate`, which supplies generic functions to extract much of what I am using `POSIXlt` for right now.

The remaining fixes are largely bug fixes on how I handle vector elements that were missed because they were hidden by the error fixed in 18-21 and 43-45.
