### PR TITLE
Removing some side effects in moves_calc

### DIFF
--- a/R/moves_calc.R
+++ b/R/moves_calc.R
@@ -103,7 +103,9 @@ moves_calc <- function(df,
   }
   dt[, moves:= school_switch(.SD), by=sid]
   dt <- dt[,list(switches=unique(moves)), by=sid]
-  output[dt, moves:=moves+switches]
   # Need to combine dt with output
-  return(output)
+  output[dt, moves:=moves+switches]
+  # Set names properly and return data.frame as supplied.
+  setnames(output, 'id', sid)
+  return(as.data.frame(output))
 }


### PR DESCRIPTION
moves_calc used to return a data.table with a new name for 'id' rather than returning a data.frame as supplied and using the 'id' value that was supplied. This cleans up the output tohave fewer side effects on the supplied data.
