### PR TITLE
Partial sorting in `nth_max`

### DIFF
--- a/R/max_mis.R
+++ b/R/max_mis.R
@@ -45,7 +45,7 @@ max_mis <- function(x){
 #' nth_max(x, n = 1) #20
 #' nth_max(x, n = 2) #19
 nth_max <- function(x, n = 1){
-  idx <- unique(x)
-  idx <- idx[order(-idx)]
-  return(idx[n])
+  x <- unique(x)
+  n <- length(x) - n + 1
+  sort(x, partial=n)[n]
 }

--- a/R/max_mis.R
+++ b/R/max_mis.R
@@ -34,7 +34,10 @@ max_mis <- function(x){
 
 #' Find the nth maximum value
 #'
-#' @param x a vector of numeric values 
+#' @note If \code{n} is smaller/larger than \code{0}/\code{length(unique(x))}
+#' the error \sQuote{index outside bounds} is thrown.
+#'
+#' @param x a vector of numeric values
 #' @param n which max to return
 #'
 #' @return the value of the nth most maximum value in a vector

--- a/man/nth_max.Rd
+++ b/man/nth_max.Rd
@@ -17,6 +17,10 @@ the value of the nth most maximum value in a vector
 \description{
 Find the nth maximum value
 }
+\note{
+If \code{n} is smaller/larger than \code{0}/\code{length(unique(x))}
+the error \sQuote{index outside bounds} is thrown.
+}
 \examples{
 x <- c(1:20, 20:1)
 nth_max(x, n = 1) #20

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -175,6 +175,8 @@ test_that("Numeric accuracy", {
   b <- c(LETTERS[c(2, 9, 3, 12, 1)])
   z <- c(121253125, 12401892377905, 31221, 12, 45, -2145125, -123, 0)
   f <- c(10, 10, 10, 10, 9, 9, 10.0001, 10.0001)
+  expect_error(nth_max(a, 100), "index .* outside bounds")
+  expect_error(nth_max(a, -1), "index .* outside bounds")
   expect_equal(nth_max(a), 20)
   expect_equal(nth_max(b, 3), "C")
   expect_equal(nth_max(z), 12401892377905)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -172,11 +172,11 @@ context("nth max")
 
 test_that("Numeric accuracy", {
   a <- c(1:20, 20:1)
-  b <- sample(LETTERS, 10)
+  b <- c(LETTERS[c(2, 9, 3, 12, 1)])
   z <- c(121253125, 12401892377905, 31221, 12, 45, -2145125, -123, 0)
   f <- c(10, 10, 10, 10, 9, 9, 10.0001, 10.0001)
   expect_equal(nth_max(a), 20)
-  expect_error(nth_max(b))
+  expect_equal(nth_max(b, 3), "C")
   expect_equal(nth_max(z), 12401892377905)
   expect_equal(nth_max(f), 10.0001)
 })


### PR DESCRIPTION
Dear Jared,

this PR replaces the `order` call in `nth_max` with partial sorting. Partial sorting is faster than `order` because `order` always sorts the complete vector first.

Please have a look at the following benchmark:
```r
library("git2r")
library("rbenchmark")

ord <- new.env()
part <- new.env()

repo <- repository("eeptools")
path <- file.path("eeptools", "R", "max_mis.R")

checkout(repo, branch="master")
source(path, local=ord)
checkout(repo, branch="partial_sorting")
source(path, local=part)

nth_max_ord <- get("nth_max", env=ord)
nth_max_part <- get("nth_max", env=part)

set.seed(123)
s <- sample(1e6, replace=TRUE)
n <- 1e4

identical(nth_max_ord(s, n), nth_max_part(s, n))
# [1] TRUE

benchmark(nth_max_ord(s, n), nth_max_part(s, n), order="relative")
#                 test replications elapsed relative
# 2 nth_max_part(s, n)          100   8.799    1.000
# 1  nth_max_ord(s, n)          100  31.422    3.571
```

What is the expected output if `n` is larger/smaller than `length(unique(x))`/`0`? 
The partial sorting throws an error and your current implementation returns `NA`.
What do you prefer?

Best wishes,

Sebastian