### PR TITLE
Removes vector response from if predicate to help R-core move this to an error condition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: eeptools
 Type: Package
 Title: Convenience Functions for Education Data
-Version: 1.2.0
-Date: 2018-05-30
+Version: 1.2.1
+Date: 2018-10-13
 Authors@R: c(person(c("Jason", "P."), "Becker", role = c("ctb"),
     email = "jason+sitemail@jbecker.co"),
     person(c("Jared", "E."), "Knowles", role=c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: eeptools
 Type: Package
 Title: Convenience Functions for Education Data
 Version: 1.2.1
-Date: 2018-10-13
 Authors@R: c(person(c("Jason", "P."), "Becker", role = c("ctb"),
     email = "jason+sitemail@jbecker.co"),
     person(c("Jared", "E."), "Knowles", role=c("aut", "cre"),
@@ -29,4 +28,6 @@ Suggests:
     MASS
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1  
+URL: https://github.com/jknowles/eeptools
+BugReports: https://github.com/jknowles/eeptools/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # NEWS
 
+## eeptools 1.2.1
+
+### Bug Fixes
+- In `max_mis`, there is an `if` predicate that checks if a class is of an invalid type. Because R objects can have multiple classes, this statement relies on the R semantics that the first value of the logical vector returned by the predicate is used. This is a feature R-core is looking to remove as it has considerable performance penalties. This check is now wrapped in `any()`, which evaluates `TRUE` if any value in the logical vector is `TRUE`.
+
 ## eeptools 1.2.0
 
 ### Added

--- a/R/age_calc.R
+++ b/R/age_calc.R
@@ -26,15 +26,15 @@
 ##' age <- age_calc(a, as.Date('2005-09-01'))
 ##' age
 age_calc <- function(dob, enddate=Sys.Date(), units='months', precise=TRUE){
-  if (!inherits(dob, "Date") | !inherits(enddate, "Date")){
+  if (!inherits(dob, "Date") | !inherits(enddate, "Date")) {
     stop("Both dob and enddate must be Date class objects")
   }
-  if(any(enddate < dob)){
+  if (any(enddate < dob)) {
     stop("End date must be a date after date of birth")
   }
   start <- as.POSIXlt(dob)
   end <- as.POSIXlt(enddate)
-  if(precise){
+  if (precise) {
     start_is_leap <- ifelse(start$year %% 400 == 0, TRUE, 
                             ifelse(start$year %% 100 == 0, FALSE,
                                    ifelse(start$year %% 4 == 0, TRUE, FALSE)))
@@ -42,24 +42,24 @@ age_calc <- function(dob, enddate=Sys.Date(), units='months', precise=TRUE){
                           ifelse(end$year %% 100 == 0, FALSE,
                                  ifelse(end$year %% 4 == 0, TRUE, FALSE)))
   }
-  if(units=='days'){
-    result <- difftime(end, start, units='days')
-  }else if(units=='months'){
-    months <- sapply(mapply(seq, as.POSIXct(start), as.POSIXct(end), 
-                            by='months', SIMPLIFY=FALSE), 
-                     length) - 1
+  if (units == 'days') {
+    result <- difftime(end, start, units = 'days')
+  } else if (units == 'months') {
+    months <- vapply(mapply(seq, as.POSIXct(start), as.POSIXct(end), 
+                            by = 'months', SIMPLIFY = FALSE), 
+                     length, FUN.VALUE = length(start)) - 1
     # length(seq(start, end, by='month')) - 1
-    if(precise){
-      month_length_end <- ifelse(end$mon==1 & end_is_leap, 29,
-                                 ifelse(end$mon==1, 28, 
+    if (precise) {
+      month_length_end <- ifelse(end$mon == 1 & end_is_leap, 29,
+                                 ifelse(end$mon == 1, 28, 
                                         ifelse(end$mon %in% c(3, 5, 8, 10), 
                                                30, 31)))
-      month_length_prior <- ifelse((end$mon-1)==1 & start_is_leap, 29, 
-                                   ifelse((end$mon-1)==1, 28, 
-                                        ifelse((end$mon-1) %in% c(3, 5, 8, 10), 
+      month_length_prior <- ifelse((end$mon - 1) == 1 & start_is_leap, 29, 
+                                   ifelse((end$mon - 1) == 1, 28, 
+                                        ifelse((end$mon - 1) %in% c(3, 5, 8, 10), 
                                                  30, 31)))
       month_frac <- ifelse(end$mday > start$mday,
-                           (end$mday-start$mday)/month_length_end,
+                           (end$mday - start$mday) / month_length_end,
                            ifelse(end$mday < start$mday, 
                                   (month_length_prior - start$mday) / 
                                     month_length_prior + 
@@ -68,23 +68,23 @@ age_calc <- function(dob, enddate=Sys.Date(), units='months', precise=TRUE){
     }else{
       result <- months
     }
-  }else if(units=='years'){
-    years <- sapply(mapply(seq, as.POSIXct(start), as.POSIXct(end), 
-                           by='years', SIMPLIFY=FALSE), 
-                    length) - 1
-    if(precise){
+  } else if (units == 'years') {
+    years <- vapply(mapply(seq, as.POSIXct(start), as.POSIXct(end), 
+                           by = 'years', SIMPLIFY = FALSE), 
+                    length, FUN.VALUE = length(start)) - 1
+    if (precise) {
       start_length <- ifelse(start_is_leap, 366, 365)
       end_length <- ifelse(end_is_leap, 366, 365)
       start_day <- ifelse(start_is_leap & start$yday >= 60,
                           start$yday - 1,
                           start$yday)
-      end_day <- ifelse(end_is_leap & end$yday >=60,
+      end_day <- ifelse(end_is_leap & end$yday >= 60,
                         end$yday - 1,
                         end$yday)
       year_frac <- ifelse(start_day < end_day,
                           (end_day - start_day)/end_length,
                           ifelse(start_day > end_day, 
-                                 (start_length-start_day) / start_length +
+                                 (start_length - start_day) / start_length +
                                    end_day / end_length, 0.0))
       result <- years + year_frac
     }else{

--- a/R/autoplot.lm.R
+++ b/R/autoplot.lm.R
@@ -23,7 +23,7 @@
 ##' 
 autoplot.lm <- function(object, which=c(1:6), mfrow=c(3,2), ...){
   df <- ggplot2::fortify(object)
-  df <- cbind(df, rows=1:nrow(df))
+  df <- cbind(df, rows = seq_len(nrow(df)))
   # residuals vs fitted
   g1 <- ggplot(df, aes(.fitted, .resid)) +
     geom_point()  +

--- a/R/max_mis.R
+++ b/R/max_mis.R
@@ -18,7 +18,7 @@
 ##' 
 max_mis <- function(x){
   varclass <- class(x)
-  if(varclass %in% c("ordered", "factor", "character")){
+  if(any(varclass %in% c("ordered", "factor", "character"))){
     stop("Vector must be of class integer or real to take maximum values")
   }
   suppressWarnings(x <- max(x, na.rm=TRUE))

--- a/R/moves_calc.R
+++ b/R/moves_calc.R
@@ -65,49 +65,46 @@ utils::globalVariables(c("moves", "switches", ".SD"))
 moves_calc <- function(df, 
                        enrollby,
                        exitby,
-                       gap=14,
-                       sid='sid', 
-                       schid='schid',
-                       enroll_date='enroll_date',
-                       exit_date='exit_date'){
+                       gap = 14,
+                       sid = 'sid', 
+                       schid = 'schid',
+                       enroll_date = 'enroll_date',
+                       exit_date = 'exit_date') {
     # df is a data.frame that minimally contains a student ID (default 'sid'),
   # a school ID (default 'schno'), and two dates an enrollment date and an 
   # exit date for each sid-schid combination.
   # Type checking inputs.
-  if (!inherits(df[[enroll_date]], "Date") | !inherits(df[[exit_date]], "Date"))
+  if (!all(inherits(df[[enroll_date]], "Date"), inherits(df[[exit_date]], "Date"))) {
       stop("Both enroll_date and exit_date must be Date objects")
+  }
   # Check if enrollby and exitby arguments are supplied. When they aren't,
   # assign them to default dates of -09-15 and -06-01 of the min and max year.
   # If they are assigned but are not date objects then 
-  if(missing(enrollby)){
-    enrollby <- as.Date(paste(year(min(df[[enroll_date]], na.rm=TRUE)),
-                              '-09-15', sep=''), format='%Y-%m-%d')
-  }else{
-    if(is.na(as.Date(enrollby, format="%Y-%m-%d"))){
-      enrollby <- as.Date(paste(year(min(df[[enroll_date]], na.rm=TRUE)),
-                                '-09-15', sep=''), format='%Y-%m-%d')
+  if (missing(enrollby)) {
+    enrollby <- as.Date(paste(year(min(df[[enroll_date]], na.rm = TRUE)),
+                              '-09-15', sep = ''), format = '%Y-%m-%d')
+  } else {
+    if (is.na(as.Date(enrollby, format = "%Y-%m-%d"))) {
+      enrollby <- as.Date(paste(year(min(df[[enroll_date]], na.rm = TRUE)),
+                                '-09-15', sep = ''), format = '%Y-%m-%d')
       warning(paste("enrollby must be a string with format %Y-%m-%d,",
                     "defaulting to", 
-                    enrollby, sep=' '))
-    }else{
-      enrollby <- as.Date(enrollby, format="%Y-%m-%d")
-    }
+                    enrollby, sep = ' '))
+    } 
   }
-  if(missing(exitby)){
-    exitby <- as.Date(paste(year(max(df[[exit_date]], na.rm=TRUE)),
-                            '-06-01', sep=''), format='%Y-%m-%d')
-  }else{
-    if(is.na(as.Date(exitby, format="%Y-%m-%d"))){
-      exitby <- as.Date(paste(year(max(df[[exit_date]], na.rm=TRUE)),
-                                '-06-01', sep=''), format='%Y-%m-%d')
+  if (missing(exitby)) {
+    exitby <- as.Date(paste(year(max(df[[exit_date]], na.rm = TRUE)),
+                            '-06-01', sep = ''), format = '%Y-%m-%d')
+  } else {
+    if (is.na(as.Date(exitby, format = "%Y-%m-%d"))) {
+      exitby <- as.Date(paste(year(max(df[[exit_date]], na.rm = TRUE)),
+                                '-06-01', sep = ''), format = '%Y-%m-%d')
       warning(paste("exitby must be a string with format %Y-%m-%d,",
                     "defaulting to", 
-                    exitby, sep=' '))
-    }else{
-      exitby <- as.Date(exitby, format="%Y-%m-%d")
-    }
+                    exitby, sep = ' '))
+    } 
   }
-  if(!is.numeric(gap)){
+  if (!is.numeric(gap)) {
     gap <- 14
     warning("gap was not a number, defaulting to 14 days")
   }
@@ -117,52 +114,53 @@ moves_calc <- function(df,
                                       length = length(unique(df[[sid]]))))
   # Students with missing data receive missing moves
   incomplete <- df[!complete.cases(df[, c(enroll_date, exit_date)]), ]
-  if(nrow(incomplete)>0){
+  if (nrow(incomplete) > 0) {
     output[which(output[['id']] %in% incomplete[[sid]]),][['moves']] <- NA
   }
-  output <- data.table(output, key='id')
+  output <- data.table(output, key = 'id')
   
   df <- df[complete.cases(df[, c(enroll_date, exit_date)]), ]
-  dt <- data.table(df, key=sid)
+  dt <- data.table(df, key = sid)
   dt[[sid]] <- as.factor(as.character(dt[[sid]]))
   setnames(dt, names(dt)[which(names(dt) %in% enroll_date)], "enroll_date")
   setnames(dt, names(dt)[which(names(dt) %in% exit_date)], "exit_date")
   dt[['moves']] <- 0
 
-  first <- dt[, list(enroll_date=min(enroll_date)), by=sid]
-  last <- dt[, list(exit_date=max(exit_date)), by=sid]
-  output[id %in% first[enroll_date>enrollby][[sid]], moves:=moves+1L]
-  output[id %in% last[exit_date<exitby][[sid]], moves:=moves+1L]
+  first <- dt[, list(enroll_date = min(enroll_date)), by = sid]
+  last <- dt[, list(exit_date = max(exit_date)), by = sid]
+  output[id %in% first[enroll_date > enrollby][[sid]], moves := moves + 1L]
+  output[id %in% last[exit_date < exitby][[sid]], moves := moves + 1L]
   
   # Select all students who have more than one row. Create a recursive function
-  # that checks that rows > 2, selects the min exit_date and difftimes the min # enroll_date thats > the exit_date value. If >gap, add 1 to counter. Remove 
+  # that checks that rows > 2, selects the min exit_date and difftimes the min 
+  # enroll_date thats > the exit_date value. If >gap, add 1 to counter. Remove 
   # observation with min exit_date, then call self with what's left. Break when
   # rows < 2 and return sid and moves counter.
-  school_switch <- function(dt, x=0){
-    if(dim(dt)[1]<2){
+  school_switch <- function(dt, x = 0){
+    if (dim(dt)[1] < 2) {
       return(x)
-    }else{
+    } else {
       exit <- min(dt[, exit_date])
-      exit_school <- dt[exit_date==exit][[schid]]
-      rows <- dt[, enroll_date]>exit
+      exit_school <- dt[exit_date == exit][[schid]]
+      rows <- dt[, enroll_date] > exit
       dt <- dt[rows,]
       enroll <- min(dt[, enroll_date])
-      enroll_school <- dt[enroll_date==enroll][[schid]]
-      if(difftime(min(dt[, enroll_date], na.rm=TRUE), exit)<gap &
-         exit_school==enroll_school){
-        y = x
-      }else if(difftime(min(dt[, enroll_date], na.rm=TRUE), exit)<gap){
-        y = x + 1L
-      }else{
-        y = x + 2L
+      enroll_school <- dt[enroll_date == enroll][[schid]]
+      if (difftime(min(dt[, enroll_date], na.rm = TRUE), exit) < gap &
+         exit_school == enroll_school) {
+        y <- x
+      } else if (difftime(min(dt[, enroll_date], na.rm = TRUE), exit) < gap) {
+        y <- x + 1L
+      } else {
+        y <- x + 2L
       }
       school_switch(dt, y)
     }
   }
-  dt[, moves:= school_switch(.SD), by=sid]
-  dt <- dt[,list(switches=unique(moves)), by=sid]
+  dt[, moves := school_switch(.SD), by = sid]
+  dt <- dt[, list(switches = unique(moves)), by = sid]
   # Need to combine dt with output
-  output[dt, moves:=moves+switches]
+  output[dt, moves := moves + switches]
   # Set names properly and return data.frame as supplied.
   setnames(output, 'id', sid)
   return(as.data.frame(output))

--- a/tests/testthat/test-edutils.R
+++ b/tests/testthat/test-edutils.R
@@ -17,6 +17,9 @@ test_that("Object fails correctly", {
   expect_error(lag_data(test_data, group="id", time="time", 
                         values=c("value1", "id"), periods = 2), 
                "Cannot lag a grouping or a time variable")
+  expect_error(lag_data(test_data, group = "id", time = "id", periods = 2,
+                        values = c("value1")),
+               "Time must be a numeric or integer value")
   expect_warning(lag_data(test_data, group="id", time="time", 
                           values=c("value1", "value2"), periods = 2.16),
                           "parameter periods has been forced to integer of value 2")

--- a/tests/testthat/test-statamode.r
+++ b/tests/testthat/test-statamode.r
@@ -1,18 +1,18 @@
 context("Correct mode selected")
 
 test_that("statamode selects the mode right for each method", {
-  expect_that(statamode("a"), matches("a"))
-  expect_that(statamode(c("a", "a", "b", "b"), method="stata"), matches("."))
-  expect_that(statamode(c("a", "a", "b", "b"), method="last"), matches("b"))
-  expect_that(statamode(c("b", "b", "a", "a"), method="last"), matches("a"))
+  expect_match(statamode("a"), "a")
+  expect_match(statamode(c("a", "a", "b", "b"), method = "stata"), ".")
+  expect_match(statamode(c("a", "a", "b", "b"), method = "last"), "b")
+  expect_match(statamode(c("b", "b", "a", "a"), method = "last"), "a")
  # expect_that(statamode(c("a", "a", "b", "b"), method="sample"), matches(c("a", "b"),all=FALSE))
 })
 
 set.seed(100)
 a <- c(3, 1, 9, 8, 4, 4, 7, 7)
-b <- statamode(a, method="last")
-c <- statamode(a, method="stata")
-d <- statamode(a, method="sample")
+b <- statamode(a, method = "last")
+c <- statamode(a, method = "stata")
+d <- statamode(a, method = "sample")
 
 
 test_that("statamode returns correct modes for each method using numbers", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -85,6 +85,7 @@ test_that("max_mis handles missing data correctly", {
   max(c(NA,NA,NA,NA),na.rm=TRUE)
   expect_identical(max_mis(c(NA,NA,NA,NA)), NA_real_)
   expect_identical(max_mis(c(NA_real_, NA_real_)), NA_real_)
+  expect_identical(max_mis(vector(mode = 'integer')), NA_integer_)
   expect_identical(max_mis(c()), NA_real_)
   expect_error(max_mis(c("A", "B", "C")))
   expect_error(max_mis(factor("A", "B", "C")))


### PR DESCRIPTION
Why:

* In `max_mis`, there is an `if` predicate that checks if a class is of an invalid type. Because R objects can have multiple classes, this statement relies on the R semantics that the first value of the logical vector returned by the predicate is used. This is a feature R-core is looking to remove as it has considerable performance penalties. See https://developer.r-project.org/Blog/public/2018/10/12/conditions-of-length-greater-than-one/index.html for the discussion of testing for this behavior change and the following report showing `eeptools` failing a why: https://github.com/kalibera/rifcond/blob/master/outputs/eeptools.Rcheck/tests/test-all.Rout.fail

This change addresses the need by:

* This check is now wrapped in `any()`, which evaluates `TRUE` if any value in the logical vector is `TRUE`.