### PR TITLE
fix typos in age_calc documentation

### DIFF
--- a/R/age_calc.R
+++ b/R/age_calc.R
@@ -1,9 +1,9 @@
 ##' Function to calculate age from date of birth.
-##' @description his function calculates age in days, months, or years from a 
+##' @description This function calculates age in days, months, or years from a 
 ##' date of birth to another arbitrary date. This returns a numeric vector in 
 ##' the specified units.
 ##' @param dob a vector of class \code{Date} representing the date of birth/start date
-##' @param enddate a vector of class Date representing the when the observation's 
+##' @param enddate a vector of class Date representing when the observation's 
 ##' age is of interest, defaults to current date.
 ##' @param units character, which units of age should be calculated? allowed values are 
 ##' days, months, and years

--- a/man/age_calc.Rd
+++ b/man/age_calc.Rd
@@ -12,7 +12,7 @@ age_calc(dob, enddate = Sys.Date(), units = "months", precise = TRUE)
 \arguments{
 \item{dob}{a vector of class \code{Date} representing the date of birth/start date}
 
-\item{enddate}{a vector of class Date representing the when the observation's 
+\item{enddate}{a vector of class Date representing when the observation's 
 age is of interest, defaults to current date.}
 
 \item{units}{character, which units of age should be calculated? allowed values are 
@@ -25,7 +25,7 @@ and leap second precision}
 A numeric vector of ages the same length as the dob vector
 }
 \description{
-his function calculates age in days, months, or years from a 
+This function calculates age in days, months, or years from a 
 date of birth to another arbitrary date. This returns a numeric vector in 
 the specified units.
 }


### PR DESCRIPTION
Hi,

While using the `age_calc` function I spotted a couple of typos in the documentation. I hope these small edits are okay.

Thanks!