### PR TITLE
Problem with and Proposed fix to to age_calc function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,8 @@ Title: Convenience Functions for Education Data
 Version: 1.2.3
 Authors@R: c(person(c("Jason", "P."), "Becker", role = c("ctb"),
     email = "jason+sitemail@jbecker.co"),
+	person("Vinay", "Bhandaru", role="ctb",
+    email="vbhandaru@gwu.edu"),
     person(c("Jared", "E."), "Knowles", role=c("aut", "cre"),
     email="jknowles@gmail.com"))
 Description: Collection of convenience functions to make working with

--- a/R/age_calc.R
+++ b/R/age_calc.R
@@ -35,6 +35,8 @@ age_calc <- function(dob, enddate=Sys.Date(), units='months', precise=TRUE){
   start <- as.POSIXlt(dob)
   end <- as.POSIXlt(enddate)
   if (precise) {
+    start$year = start$year+1900
+    end$year = end$year+1900
     start_is_leap <- ifelse(start$year %% 400 == 0, TRUE, 
                             ifelse(start$year %% 100 == 0, FALSE,
                                    ifelse(start$year %% 4 == 0, TRUE, FALSE)))


### PR DESCRIPTION
The function age_calc as it's currenly defined incorrectly classifies certain century years as leap or non-leap years. For example, it erroneously treats 1900 as a leap year and 2000 as a non-leap year. The algorithm used in age_calc to define leap years is correct in that years divisible by 4 are considered leap years except if the year is not divisible by 400 but divisible by 100, such as 1900. The problem is that it doesn't use the actual year for the user-supplied dates. Instead it uses the year from the date object after it's converted to a POSIXlt object.  The year from a POSIXlt object is the actual year minus 1900:

"Year values are stored using a base index value of 1900. Thus, 2015 is stored as 115 ($year = 115)"
https://www.neonscience.org/resources/learning-hub/tutorials/dc-convert-date-time-posix-r

**Why is 1900 misclassified as a leap year in age_calc?**
1900 is divisible by 100 but not by 400, so is not a leap year. However, POSIXlt stores it as 0 which is divisible by any number other than 0. Hence, 1900 is incorrectly treated as a leap year in age_calc.

**Why is 2000 misclassified as a non-leap year in age_calc?**
2000 is divisible by 400, so it's a leap year. However, POXIXlt stores it as 100 which is not divisible by 400 but is divisible by 100. Hence, it is not treated as a leap year in age_calc.

The fix that I propose simply adds 1900 to the POSIXlt year value so that the algorthm uses the correct numeric value for the year to determine whether it's a leap or non-leap year.